### PR TITLE
Update Polyfill and use NPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN \
 	git clone https://github.com/Financial-Times/polyfill-service . && \
 	git checkout ${POLYFILL_TAG} && \
 	rm -rf .git && \
-	yarn install && \
+	npm ci && \
 	sed -i.bak -e 's,^node,exec node,' start_server.sh && \
 	mv start_server.sh /bin/ && \
 	chmod a+x /bin/start_server.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:10.15.3-alpine
+FROM node:12-alpine
 
 RUN apk add --no-cache --update bash
 RUN apk add --no-cache --update --virtual build git python make gcc g++
 WORKDIR /polyfill
-ARG POLYFILL_TAG='v4.8.1'
+ARG POLYFILL_TAG='v4.38.0'
 ARG NODE_ENV='production'
 RUN \
 	git clone https://github.com/Financial-Times/polyfill-service . && \


### PR DESCRIPTION
This updates the version of Polyfill to the most recent tagged version. It also switches to installing it via NPM, because with NPM we get the benefit of the existing lockfile (and we also don't end up with the yarn cache polluting our image).